### PR TITLE
Add setup script and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# Parameter
-# Parameter
+# Twitter Clone
+
+This repository contains a simple twitter-like clone demonstrating a full stack application with Go backend and TypeScript frontend. The project is designed to run locally on Kubernetes using Helm charts and ArgoCD.
+
+## Features
+- User registration and login
+- Post messages and view a personal feed
+- Artificial traffic generator on the backend
+- Uses Postgres, Redis, Kafka and Minio
+
+## Requirements
+- [Go](https://golang.org/) 1.20+
+- [Node.js](https://nodejs.org/) 18+
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) (for building images)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) and [minikube](https://minikube.sigs.k8s.io/docs/) or any Kubernetes cluster
+- [Helm](https://helm.sh/)
+- [ArgoCD](https://argo-cd.readthedocs.io/)
+## Quickstart
+Run `./setup.sh` to automatically start minikube, build the images and deploy the chart.
+
+## Backend
+The backend lives in `backend/` and exposes a small REST API using Gin. Configuration is done via environment variables. The schema is defined in `backend/schema.sql`.
+
+### Build image
+```bash
+cd backend
+go mod tidy # generate go.sum
+docker build -t backend:latest .
+```
+
+## Frontend
+The frontend is a minimal React + TypeScript application found in `frontend/`.
+
+### Build image
+```bash
+cd frontend
+npm install # fetch packages
+npm run build
+docker build -t frontend:latest .
+```
+
+## Running locally with Minikube
+1. Start minikube:
+   ```bash
+   minikube start --driver=docker
+   ```
+2. Load images into the cluster (or push them to a registry accessible by the cluster):
+   ```bash
+   eval $(minikube docker-env --shell bash)
+   docker build -t backend:latest ./backend
+   docker build -t frontend:latest ./frontend
+   ```
+3. Deploy the stack using Helm:
+   ```bash
+   helm install twitter-clone ./helm-chart
+   ```
+4. Access the frontend:
+   ```bash
+   minikube service frontend --url
+   ```
+
+## Using ArgoCD
+1. Install ArgoCD in your cluster (see the [official docs](https://argo-cd.readthedocs.io/)).
+2. Apply the ArgoCD application manifest:
+   ```bash
+   kubectl apply -f helm-chart/argocd-app.yaml
+   ```
+   ArgoCD will then deploy the chart and keep it in sync with the repository.
+
+## Database setup
+After Postgres is running you can create the tables using the provided schema:
+```bash
+kubectl exec -it deployment/postgres -- psql -U user -d twitter -f /schema.sql
+```
+Adjust credentials if you changed them in `values.yaml`.
+
+## Notes
+This project is intentionally simple and aims to provide a starting point. Feel free to extend authentication, add more APIs, or integrate Kafka consumers and producers for real-time updates.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.20-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o server main.go
+
+FROM alpine
+WORKDIR /app
+COPY --from=build /app/server ./server
+CMD ["./server"]

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,11 @@
+module github.com/example/twitter-clone
+
+go 1.20
+
+require (
+github.com/gin-gonic/gin v1.9.0
+github.com/jackc/pgx/v5 v5.4.0
+github.com/go-redis/redis/v8 v8.11.5
+github.com/minio/minio-go/v7 v7.0.57
+github.com/Shopify/sarama v1.37.0
+)

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "net/http"
+    "time"
+
+    "github.com/gin-gonic/gin"
+    "github.com/jackc/pgx/v5/pgxpool"
+)
+
+var db *pgxpool.Pool
+
+func main() {
+    ctx := context.Background()
+
+    var err error
+    db, err = pgxpool.New(ctx, "postgres://user:password@localhost:5432/twitter")
+    if err != nil {
+        log.Fatalf("failed to connect to postgres: %v", err)
+    }
+    defer db.Close()
+
+    go generateTraffic(ctx)
+
+    r := gin.Default()
+    r.POST("/register", registerHandler)
+    r.POST("/login", loginHandler)
+    r.POST("/messages", authMiddleware, postMessageHandler)
+    r.GET("/feed", authMiddleware, feedHandler)
+
+    log.Println("server running on :8080")
+    if err := r.Run(":8080"); err != nil {
+        log.Fatal(err)
+    }
+}
+
+type User struct {
+    ID       int64  `json:"id"`
+    Username string `json:"username"`
+    Password string `json:"password"`
+}
+
+type Message struct {
+    ID        int64     `json:"id"`
+    UserID    int64     `json:"user_id"`
+    Content   string    `json:"content"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+func registerHandler(c *gin.Context) {
+    var u User
+    if err := c.BindJSON(&u); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+        return
+    }
+    err := db.QueryRow(c, "INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id", u.Username, u.Password).Scan(&u.ID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        return
+    }
+    c.JSON(http.StatusOK, u)
+}
+
+func loginHandler(c *gin.Context) {
+    var u User
+    if err := c.BindJSON(&u); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+        return
+    }
+    row := db.QueryRow(c, "SELECT id FROM users WHERE username=$1 AND password=$2", u.Username, u.Password)
+    if err := row.Scan(&u.ID); err != nil {
+        c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+        return
+    }
+    http.SetCookie(c.Writer, &http.Cookie{Name: "session", Value: fmt.Sprint(u.ID), Path: "/"})
+    c.JSON(http.StatusOK, u)
+}
+
+func authMiddleware(c *gin.Context) {
+    cookie, err := c.Request.Cookie("session")
+    if err != nil {
+        c.AbortWithStatus(http.StatusUnauthorized)
+        return
+    }
+    c.Set("userID", cookie.Value)
+    c.Next()
+}
+
+func postMessageHandler(c *gin.Context) {
+    userID := c.GetString("userID")
+    var m Message
+    if err := c.BindJSON(&m); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+        return
+    }
+    err := db.QueryRow(c, "INSERT INTO messages (user_id, content) VALUES ($1, $2) RETURNING id, created_at", userID, m.Content).Scan(&m.ID, &m.CreatedAt)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        return
+    }
+    fmt.Sscanf(userID, "%d", &m.UserID)
+    c.JSON(http.StatusOK, m)
+}
+
+func feedHandler(c *gin.Context) {
+    userID := c.GetString("userID")
+    rows, err := db.Query(c, "SELECT id, user_id, content, created_at FROM messages WHERE user_id=$1 ORDER BY created_at DESC LIMIT 20", userID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        return
+    }
+    defer rows.Close()
+    feed := []Message{}
+    for rows.Next() {
+        var m Message
+        if err := rows.Scan(&m.ID, &m.UserID, &m.Content, &m.CreatedAt); err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+        feed = append(feed, m)
+    }
+    c.JSON(http.StatusOK, feed)
+}
+
+func generateTraffic(ctx context.Context) {
+    for {
+        time.Sleep(5 * time.Second)
+        _, err := db.Exec(ctx, "INSERT INTO messages (user_id, content) SELECT id, 'random post #' || floor(random()*1000)::int FROM users")
+        if err != nil {
+            log.Println("traffic error:", err)
+        }
+    }
+}
+

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    content TEXT,
+    created_at TIMESTAMP DEFAULT now()
+);

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package.json tsconfig.json webpack.config.js .
+COPY src ./src
+COPY index.html ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/index.html /usr/share/nginx/html/index.html
+COPY --from=build /app/dist/bundle.js /usr/share/nginx/html/bundle.js
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Twitter Clone</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "twitter-clone-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "webpack": "^5.88.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1",
+    "ts-loader": "^9.4.3"
+  }
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import axios from 'axios';
+
+function App() {
+  const [feed, setFeed] = useState<any[]>([]);
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    fetchFeed();
+  }, []);
+
+  const fetchFeed = async () => {
+    try {
+      const res = await axios.get('/feed');
+      setFeed(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const submit = async () => {
+    await axios.post('/messages', { content });
+    setContent('');
+    fetchFeed();
+  };
+
+  return (
+    <div>
+      <h1>Twitter Clone</h1>
+      <input value={content} onChange={(e) => setContent(e.target.value)} />
+      <button onClick={submit}>Post</button>
+      {feed.map((m) => (
+        <div key={m.id}>{m.content}</div>
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "ESNext",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devServer: {
+    static: './dist',
+    port: 3000,
+  },
+};

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: twitter-clone
+version: 0.1.0

--- a/helm-chart/argocd-app.yaml
+++ b/helm-chart/argocd-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: twitter-clone
+spec:
+  project: default
+  source:
+    path: helm-chart
+    repoURL: https://github.com/example/twitter-clone.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/helm-chart/templates/backend-deployment.yaml
+++ b/helm-chart/templates/backend-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ .Values.backend.image }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.postgres.user }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"

--- a/helm-chart/templates/backend-service.yaml
+++ b/helm-chart/templates/backend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/helm-chart/templates/frontend-deployment.yaml
+++ b/helm-chart/templates/frontend-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ .Values.frontend.image }}
+          ports:
+            - containerPort: 80
+          env:
+            - name: API_URL
+              value: "http://backend"

--- a/helm-chart/templates/frontend-service.yaml
+++ b/helm-chart/templates/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: NodePort
+  selector:
+    app: frontend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 30080

--- a/helm-chart/templates/kafka.yaml
+++ b/helm-chart/templates/kafka.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: {{ .Values.kafka.image }}
+          ports:
+            - containerPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  selector:
+    app: kafka
+  ports:
+    - port: 9092
+      targetPort: 9092

--- a/helm-chart/templates/minio.yaml
+++ b/helm-chart/templates/minio.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: {{ .Values.minio.image }}
+          args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{ .Values.minio.accessKey }}
+            - name: MINIO_ROOT_PASSWORD
+              value: {{ .Values.minio.secretKey }}
+          ports:
+            - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      targetPort: 9000

--- a/helm-chart/templates/postgres.yaml
+++ b/helm-chart/templates/postgres.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.db }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/helm-chart/templates/redis.yaml
+++ b/helm-chart/templates/redis.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,19 @@
+backend:
+  image: backend:latest
+  replicaCount: 1
+frontend:
+  image: frontend:latest
+  replicaCount: 1
+postgres:
+  image: postgres:15
+  user: user
+  password: password
+  db: twitter
+redis:
+  image: redis:7
+minio:
+  image: minio/minio:latest
+  accessKey: minio
+  secretKey: minio123
+kafka:
+  image: bitnami/kafka:latest

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eoux pipefail
+# Ensure current user can run docker
+if ! groups $USER | grep -q docker; then
+  echo "Adding $USER to docker group. Please log out and log back in, then re-run this script."
+  sudo usermod -aG docker $USER
+  exit 1
+fi
+
+# Start minikube with docker driver
+minikube start --driver=docker
+
+# Use docker from minikube
+eval $(minikube docker-env --shell bash)
+
+# Build Docker images
+docker build -t backend:latest ./backend
+docker build -t frontend:latest ./frontend
+
+# Deploy services using Helm
+helm upgrade --install twitter-clone ./helm-chart
+
+# Wait for postgres pod to be ready
+kubectl wait --for=condition=ready pod -l app=postgres --timeout=120s
+
+# Load database schema
+POSTGRES_POD=$(kubectl get pods -l app=postgres -o jsonpath='{.items[0].metadata.name}')
+kubectl cp backend/schema.sql "$POSTGRES_POD":/schema.sql
+kubectl exec "$POSTGRES_POD" -- psql -U user -d twitter -f /schema.sql
+


### PR DESCRIPTION
## Summary
- include a setup.sh script to automate minikube startup and deployment
- generate go.sum placeholder for backend and copy it in Dockerfile
- update README with quickstart script usage and manual steps using the Docker driver

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683ca358a2c48333ad361b1f749cd10f