### PR TITLE
Fix Dockerfile to include go.sum

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20-alpine AS build
 WORKDIR /app
 
-COPY go.mod .
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go build -o server main.go
@@ -9,4 +9,5 @@ RUN go build -o server main.go
 FROM alpine
 WORKDIR /app
 COPY --from=build /app/server ./server
+COPY --from=build /app/go.sum ./go.sum
 CMD ["./server"]


### PR DESCRIPTION
## Summary
- ensure go.sum is copied before `go mod download`
- pass go.sum to the runtime stage to keep it in the image

## Testing
- `go build` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_b_683cc2b58bd88333a869e5c3aec7e93e