### PR TITLE
Fix Kafka deployment and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The backend lives in `backend/` and exposes a small REST API using Gin. Configur
 ### Build image
 ```bash
 cd backend
+go mod tidy # ensure dependencies
 docker build -t backend:latest .
 ```
 
@@ -59,6 +60,7 @@ The steps below outline what the script performs manually.
    ```bash
    eval $(minikube docker-env)
 
+   (cd backend && go mod tidy)
    docker build -t backend:latest ./backend
    docker build -t frontend:latest ./frontend
    ```

--- a/helm-chart/templates/backend-deployment.yaml
+++ b/helm-chart/templates/backend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: backend
           image: {{ .Values.backend.image }}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
           env:

--- a/helm-chart/templates/frontend-deployment.yaml
+++ b/helm-chart/templates/frontend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: frontend
           image: {{ .Values.frontend.image }}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           env:

--- a/helm-chart/templates/kafka.yaml
+++ b/helm-chart/templates/kafka.yaml
@@ -15,6 +15,12 @@ spec:
       containers:
         - name: kafka
           image: {{ .Values.kafka.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: zookeeper:2181
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
           ports:
             - containerPort: 9092
 ---

--- a/helm-chart/templates/zookeeper.yaml
+++ b/helm-chart/templates/zookeeper.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: {{ .Values.zookeeper.image }}
+          ports:
+            - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      targetPort: 2181

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,3 +17,5 @@ minio:
   secretKey: minio123
 kafka:
   image: bitnami/kafka:latest
+zookeeper:
+  image: bitnami/zookeeper:latest


### PR DESCRIPTION
## Summary
- restore `go mod tidy` step in README
- run `go mod tidy` before building images in manual steps
- add env vars and `imagePullPolicy` to Kafka deployment
- deploy Zookeeper for Kafka

## Testing
- `helm template test ./helm-chart` *(fails: helm not installed)*
- `cd backend && go mod tidy` *(fails: no network access to download modules)*

------
https://chatgpt.com/codex/tasks/task_b_683cc2db463c83338f640d989cb6934d