### PR TITLE
Add zookeeper and tidy step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The backend lives in `backend/` and exposes a small REST API using Gin. Configur
 ### Build image
 ```bash
 cd backend
+go mod tidy # ensure dependencies
 docker build -t backend:latest .
 ```
 
@@ -58,6 +59,8 @@ The steps below outline what the script performs manually.
 2. Load images into the cluster (or push them to a registry accessible by the cluster):
    ```bash
    eval $(minikube docker-env)
+
+   (cd backend && go mod tidy)
 
    docker build -t backend:latest ./backend
    docker build -t frontend:latest ./frontend

--- a/helm-chart/templates/backend-deployment.yaml
+++ b/helm-chart/templates/backend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: backend
           image: {{ .Values.backend.image }}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
           env:

--- a/helm-chart/templates/frontend-deployment.yaml
+++ b/helm-chart/templates/frontend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: frontend
           image: {{ .Values.frontend.image }}
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           env:

--- a/helm-chart/templates/kafka.yaml
+++ b/helm-chart/templates/kafka.yaml
@@ -15,6 +15,12 @@ spec:
       containers:
         - name: kafka
           image: {{ .Values.kafka.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: zookeeper:2181
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
           ports:
             - containerPort: 9092
 ---

--- a/helm-chart/templates/zookeeper.yaml
+++ b/helm-chart/templates/zookeeper.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: {{ .Values.zookeeper.image }}
+          env:
+            - name: ALLOW_ANONYMOUS_LOGIN
+              value: "yes"
+          ports:
+            - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      targetPort: 2181

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,3 +17,5 @@ minio:
   secretKey: minio123
 kafka:
   image: bitnami/kafka:latest
+zookeeper:
+  image: bitnami/zookeeper:latest

--- a/setup.sh
+++ b/setup.sh
@@ -9,10 +9,8 @@ if ! groups $USER_NAME | grep -q '\bdocker\b'; then
   sudo usermod -aG docker $USER_NAME && newgrp docker
 fi
 
-# Ensure Go modules are downloaded
-if [ ! -f backend/go.sum ]; then
-  (cd backend && go mod tidy)
-fi
+# Run go mod tidy so dependencies are available
+(cd backend && go mod tidy)
 
 # Start minikube with docker driver
 minikube start --driver=docker


### PR DESCRIPTION
## Summary
- run `go mod tidy` in the setup script
- mention `go mod tidy` in manual build steps
- add Zookeeper deployment for Kafka
- configure Kafka container to use Zookeeper
- add default Zookeeper image in chart values

## Testing
- `helm template test ./helm-chart` *(fails: helm not installed)*
- `cd backend && go mod tidy` *(fails to fetch modules due to no network)*

------
https://chatgpt.com/codex/tasks/task_b_683cc2db463c83338f640d989cb6934d