### PR TITLE
Init Redis and Kafka clients

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,8 +3,10 @@ module github.com/example/twitter-clone
 go 1.20
 
 require (
-	github.com/gin-gonic/gin v1.9.0
-	github.com/jackc/pgx/v5 v5.4.0
+        github.com/gin-gonic/gin v1.9.0
+        github.com/jackc/pgx/v5 v5.4.0
+        github.com/redis/go-redis/v9 v9.0.0
+        github.com/segmentio/kafka-go v0.4.0
 )
 
 require (

--- a/backend/infra.go
+++ b/backend/infra.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/segmentio/kafka-go"
+)
+
+func newRedisClient() *redis.Client {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+	return redis.NewClient(&redis.Options{Addr: addr})
+}
+
+func newKafkaWriter() *kafka.Writer {
+	addr := os.Getenv("KAFKA_ADDR")
+	if addr == "" {
+		addr = "localhost:9092"
+	}
+	return kafka.NewWriter(kafka.WriterConfig{
+		Brokers: []string{addr},
+		Topic:   "events",
+	})
+}

--- a/backend/infra_test.go
+++ b/backend/infra_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewRedisClient(t *testing.T) {
+	os.Setenv("REDIS_ADDR", "127.0.0.1:9999")
+	c := newRedisClient()
+	if c == nil {
+		t.Fatal("client nil")
+	}
+	if c.Options().Addr != "127.0.0.1:9999" {
+		t.Fatalf("expected addr 127.0.0.1:9999 got %s", c.Options().Addr)
+	}
+	_ = c.Close()
+}
+
+func TestNewKafkaWriter(t *testing.T) {
+	os.Setenv("KAFKA_ADDR", "127.0.0.1:9093")
+	w := newKafkaWriter()
+	if w == nil {
+		t.Fatal("writer nil")
+	}
+	if len(w.Stats().Brokers) == 0 || w.Stats().Brokers[0].BrokerAddress != "127.0.0.1:9093" {
+		t.Fatalf("unexpected broker address")
+	}
+	_ = w.Close()
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,15 +11,25 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+	"github.com/segmentio/kafka-go"
 )
 
 var (
-	db    *pgxpool.Pool
-	store Store
+	db          *pgxpool.Pool
+	store       Store
+	redisClient *redis.Client
+	kafkaWriter *kafka.Writer
 )
 
 func main() {
 	ctx := context.Background()
+
+	redisClient = newRedisClient()
+	defer redisClient.Close()
+
+	kafkaWriter = newKafkaWriter()
+	defer kafkaWriter.Close()
 
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -115,6 +125,12 @@ func postMessageHandler(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	if err := redisClient.Set(c, fmt.Sprintf("message:%d", msg.ID), m.Content, 0).Err(); err != nil {
+		log.Println("redis set:", err)
+	}
+	if err := kafkaWriter.WriteMessages(c, kafka.Message{Value: []byte(m.Content)}); err != nil {
+		log.Println("kafka write:", err)
+	}
 	c.JSON(http.StatusOK, msg)
 }
 
@@ -132,7 +148,6 @@ func feedHandler(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, feed)
 }
-
 
 func setupRouter() *gin.Engine {
 	r := gin.Default()

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,6 +1,5 @@
 package main
 
-
 import "testing"
 
 func TestDummy(t *testing.T) {}

--- a/backend/store.go
+++ b/backend/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-
 // Store abstracts database operations so they can be backed by Postgres or an in-memory implementation for tests.
 type Store interface {
 	CreateUser(ctx context.Context, username, password string) (User, error)
@@ -126,4 +125,3 @@ func (m *memStore) GetFeed(ctx context.Context, userID int64) ([]Message, error)
 	}
 	return feed, nil
 }
-


### PR DESCRIPTION
## Summary
- add Redis and Kafka packages
- initialize Redis and Kafka connections in backend
- publish messages to Kafka and cache them in Redis
- add unit tests for the new initialization helpers
- format Go source files

## Testing
- `go vet ./...` *(fails: missing go.sum entries because network access is disabled)*
- `go test ./...` *(fails: missing go.sum entries because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_b_683dd15cd8a483338ad9fb86553fde92