### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/yonatan895/Parameter/security/code-scanning/5](https://github.com/yonatan895/Parameter/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: read` for caching Docker layers.
- `actions: read` for interacting with GitHub Actions artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
